### PR TITLE
Rename GCP terraform provider variables

### DIFF
--- a/terraform/stage/main.tf
+++ b/terraform/stage/main.tf
@@ -1,7 +1,7 @@
 // Configure the Google Cloud provider
 provider "google" {
-  project = "${var.project}"
-  region  = "${var.region}"
+  project = "${var.google_project}"
+  region  = "${var.google_region}"
 }
 
 /* Ensure firewall rule for SSH access to all instances

--- a/terraform/stage/terraform.tfvars.example
+++ b/terraform/stage/terraform.tfvars.example
@@ -2,7 +2,7 @@
 # Google Cloud Provider variables
 #################################
 
-project = "YOUR_PROJECT_STAGE"
+google_project = "YOUR_PROJECT_STAGE"
 
 #################################
 # Github variables

--- a/terraform/stage/variables.tf
+++ b/terraform/stage/variables.tf
@@ -11,6 +11,11 @@ variable "google_region" {
   description = "The region to operate under"
 }
 
+variable "google_version" {
+  default = "~> 0.1"
+  description = "The version of provider module"
+}
+
 #################################
 # Github Provider variables
 #################################

--- a/terraform/stage/variables.tf
+++ b/terraform/stage/variables.tf
@@ -2,11 +2,11 @@
 # Google Cloud Provider variables
 #################################
 
-variable "project" {
+variable "google_project" {
   description = "The ID of the project"
 }
 
-variable "region" {
+variable "google_region" {
   default     = "europe-west1"
   description = "The region to operate under"
 }


### PR DESCRIPTION
Prefix all GCP provider variable with `google_`.

Also add `version` with default value `~> 0.1` to GCP provider.