### PR TITLE
Add Vagrantfile with infra configuration to ansible folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Vagrant
 .vagrant
+*.log
 
 # Terraform
 *.tfstate

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -1,0 +1,39 @@
+Vagrant.configure("2") do |config|
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = 512
+  end
+
+  config.vm.define "dbserver" do |db|
+    db.vm.box = "ubuntu/xenial64"
+    db.vm.hostname = "dbserver"
+    db.vm.network :private_network, ip: "10.10.10.10"
+    db.vm.provision "ansible" do |ansible|
+      ansible.compatibility_mode = "2.0"
+      ansible.playbook = "db.yml"
+      ansible.groups = {
+      "tag_db" => ["dbserver"],
+      "tag_db:vars" => {
+        "mongodb_bind_ip" => "0.0.0.0",
+        }
+      }
+    end
+  end
+
+  config.vm.define "appserver" do |app|
+    app.vm.box = "ubuntu/xenial64"
+    app.vm.hostname = "appserver"
+    app.vm.network :private_network, ip: "10.10.10.20"
+    app.vm.provision "ansible" do |ansible|
+      ansible.compatibility_mode = "2.0"
+      ansible.playbook = "app.yml"
+      ansible.groups = {
+      "tag_app" => ["appserver"],
+      "tag_app:vars" => {
+        "reddit_app_user" => "ubuntu",
+        "reddit_app_db_host" => "10.10.10.10",
+        }
+      }
+    end
+  end
+end

--- a/ansible/app.yml
+++ b/ansible/app.yml
@@ -1,7 +1,19 @@
 ---
 
 - hosts: tag_app
+  gather_facts: false
   become: true
+
+  pre_tasks:
+    - name: Ensure python 2.7 is present
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      register: output
+      changed_when:
+        - output.stdout != ""
+        - output.stdout != "\r\n"
+    - name: Gather facts
+      setup:
+
   roles:
     - ansible-role-ruby
     - ansible-role-reddit-app

--- a/ansible/db.yml
+++ b/ansible/db.yml
@@ -1,6 +1,18 @@
 ---
 
 - hosts: tag_db
+  gather_facts: false
   become: true
+
+  pre_tasks:
+    - name: Ensure python 2.7 is present
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      register: output
+      changed_when:
+        - output.stdout != ""
+        - output.stdout != "\r\n"
+    - name: Gather facts
+      setup:
+
   roles:
     - ansible-role-mongodb

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,0 +1,4 @@
+ansible==2.3.2
+molecule==2.1.0
+testinfra==1.6.3
+python-vagrant==0.5.15


### PR DESCRIPTION
PR в рамках ДЗ 13. Особо ничего сильно не трогал. Добавил лишь Vagrantfile и установку Python 2.7 в плейбуки `ap.yml` и `db.yml`.

1. Все ансибл роли я вынес ранее #23 в отдельные репозитарии

- https://github.com/jugatsu-infra/ansible-role-mongodb
- https://github.com/jugatsu-infra/ansible-role-ruby
- https://github.com/jugatsu-infra/ansible-role-reddit-app

2. На всех ролях, кроме `ansible-role-reddit-app` настроено локальное тестирование при помощи Molecule. Роли также покрыты тестами.

3. Все конфигурационные файлы пакера перестроены на использование ансибл ролей ранее в рамках #25 . Там я всё таки решил использовать врапперы и уже инклудить роли. Пытаться переиспользовать site.yml показалось излишним.

4. В Vagrantfile используются группы с префиксом `tag_`, поскольку у меня проект построен вокруг динамического GCP инвентори, отсутствует статический файл hosts. На это будет акцент в документации. Думаю добавить ещё статический файл `hosts.ini.example`
5.  Настройка Travis CI и оповещение в работе https://github.com/jugatsu-infra/ansible-role-mongodb/issues/7
6. Настройка Molecule и GCE также в работе https://github.com/jugatsu-infra/ansible-role-mongodb/issues/6. Пока бранч не пушил. Но инстанс создаётся уже. Осталось с ssh ключами разобраться.
7. ~~Ну и документация как обычно в работе :) #10~~ UPDATED: #42 

Релиз репозитория `infra` версии v1.0.0 ведётся в рамках https://github.com/jugatsu/infra/milestone/1 