### PR TITLE
Move GCP terraform provider config to provider.tf

### DIFF
--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,11 +1,3 @@
-// Configure the Google Cloud provider
-provider "google" {
-  version = "= 0.1.3"
-
-  project = "${var.google_project}"
-  region  = "${var.google_region}"
-}
-
 /* Ensure firewall rule for SSH access to all instances
    is present and configured */
 module "firewall_ssh" {

--- a/terraform/prod/provider.tf
+++ b/terraform/prod/provider.tf
@@ -1,0 +1,7 @@
+// Configure the Google Cloud provider
+provider "google" {
+  version = "= 0.1.3"
+
+  project = "${var.google_project}"
+  region  = "${var.google_region}"
+}

--- a/terraform/stage/main.tf
+++ b/terraform/stage/main.tf
@@ -1,11 +1,3 @@
-// Configure the Google Cloud provider
-provider "google" {
-  version = "~> 0.1"
-
-  project = "${var.google_project}"
-  region  = "${var.google_region}"
-}
-
 /* Ensure firewall rule for SSH access to all instances
    is present and configured */
 module "firewall_ssh" {

--- a/terraform/stage/provider.tf
+++ b/terraform/stage/provider.tf
@@ -1,0 +1,7 @@
+// Configure the Google Cloud provider
+provider "google" {
+  version = "~> 0.1"
+
+  project = "${var.google_project}"
+  region  = "${var.google_region}"
+}


### PR DESCRIPTION
Use separate config file `provider.tf` for terraform provider's configuration.

Closes #31 